### PR TITLE
[gdal]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# gdal
+
+GDAL is a translator library for raster and vector geospatial data formats
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.gdal?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # gdal
 
 GDAL is a translator library for raster and vector geospatial data formats

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_relative_path: '/bin/gdalenhance'
+command_relative_path: 'bin/gdalenhance'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/bin/gdalenhance'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_path: '/bin/gdalenhance'
+command_relative_path: '/bin/gdalenhance'

--- a/controls/gdal_exists.rb
+++ b/controls/gdal_exists.rb
@@ -13,6 +13,7 @@ control 'core-plans-gdal-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
   command_relative_path = input('command_relative_path', value: 'bin/gdalenhance')

--- a/controls/gdal_exists.rb
+++ b/controls/gdal_exists.rb
@@ -1,17 +1,23 @@
 title 'Tests to confirm gdal exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdal')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-gdal_relative_path = input('command_path', value: '/bin/gdalenhance')
-gdal_installation_directory = command("hab pkg path #{plan_ident}")
-gdal_full_path = gdal_installation_directory.stdout.strip + "#{ gdal_relative_path}"
- 
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+command_relative_path = input('command_relative_path', value: '/bin/gdalenhance')
+command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+
 control 'core-plans-gdal-exists' do
   impact 1.0
   title 'Ensure gdal exists'
   desc '
-  '
-   describe file(gdal_full_path) do
+  Verify gdal by ensuring /bin/gdalenhance exists'
+  
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/gdal_exists.rb
+++ b/controls/gdal_exists.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm gdal exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdal')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-command_relative_path = input('command_relative_path', value: '/bin/gdalenhance')
-command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
 
 control 'core-plans-gdal-exists' do
   impact 1.0
@@ -12,11 +9,14 @@ control 'core-plans-gdal-exists' do
   desc '
   Verify gdal by ensuring /bin/gdalenhance exists'
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
 
+  command_relative_path = input('command_relative_path', value: '/bin/gdalenhance')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/gdal_exists.rb
+++ b/controls/gdal_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm gdal exists'
+
+plan_name = input('plan_name', value: 'gdal')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+gdal_relative_path = input('command_path', value: '/bin/gdalenhance')
+gdal_installation_directory = command("hab pkg path #{plan_ident}")
+gdal_full_path = gdal_installation_directory.stdout.strip + "#{ gdal_relative_path}"
+ 
+control 'core-plans-gdal-exists' do
+  impact 1.0
+  title 'Ensure gdal exists'
+  desc '
+  '
+   describe file(gdal_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/gdal_exists.rb
+++ b/controls/gdal_exists.rb
@@ -7,7 +7,7 @@ control 'core-plans-gdal-exists' do
   impact 1.0
   title 'Ensure gdal exists'
   desc '
-  Verify gdal by ensuring /bin/gdalenhance exists'
+  Verify gdal by ensuring bin/gdalenhance exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -15,8 +15,8 @@ control 'core-plans-gdal-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/gdalenhance')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'bin/gdalenhance')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/gdal_works.rb
+++ b/controls/gdal_works.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm gdal works as expected'
+
+plan_name = input('plan_name', value: 'gdal')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+
+control 'core-plans-gdal-works' do
+  impact 1.0
+  title 'Ensure gdal works as expected'
+  desc '
+  '
+  gdal_path = command("hab pkg path #{plan_ident}")
+  describe gdal_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  gdal_pkg_ident = ((gdal_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  describe command("DEBUG=true; hab pkg exec #{ gdal_pkg_ident} gdalenhance --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /GDAL 2.4.0/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/gdal_works.rb
+++ b/controls/gdal_works.rb
@@ -7,8 +7,9 @@ control 'core-plans-gdal-works' do
   impact 1.0
   title 'Ensure gdal works as expected'
   desc '
-  Verify gdal by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version
+  Verify gdal by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -17,9 +18,10 @@ control 'core-plans-gdal-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gdalenhance --version") do
+  command_relative_path = input('command_relative_path', value: 'bin/gdalenhance')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /GDAL #{plan_pkg_version}/ }

--- a/controls/gdal_works.rb
+++ b/controls/gdal_works.rb
@@ -16,6 +16,7 @@ control 'core-plans-gdal-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
   command_relative_path = input('command_relative_path', value: 'bin/gdalenhance')

--- a/controls/gdal_works.rb
+++ b/controls/gdal_works.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm gdal works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdal')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-gdal-works' do
   impact 1.0
@@ -14,11 +11,14 @@ control 'core-plans-gdal-works' do
   it returns the expected version
   '
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
   describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gdalenhance --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/controls/gdal_works.rb
+++ b/controls/gdal_works.rb
@@ -1,24 +1,28 @@
 title 'Tests to confirm gdal works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gdal')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-gdal-works' do
   impact 1.0
   title 'Ensure gdal works as expected'
   desc '
+  Verify gdal by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
-  gdal_path = command("hab pkg path #{plan_ident}")
-  describe gdal_path do
+  
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
-  gdal_pkg_ident = ((gdal_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  describe command("DEBUG=true; hab pkg exec #{ gdal_pkg_ident} gdalenhance --version") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gdalenhance --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /GDAL 2.4.0/ }
+    its('stdout') { should match /GDAL #{plan_pkg_version}/ }
     its('stderr') { should be_empty }
   end
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: gdal
+title: Habitat Core Plan gdal
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan gdal
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,33 @@
+pkg_name=gdal
+pkg_origin=core
+pkg_version=2.4.0
+pkg_description="GDAL is a translator library for raster and vector geospatial data formats"
+pkg_upstream_url=http://www.gdal.org/
+pkg_license=('MIT')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=http://download.osgeo.org/gdal/${pkg_version}/gdal-${pkg_version}.tar.gz
+pkg_shasum=a568cf3dc7bb203ae12a48e1eb2a42302cded499ef6eccaf9e8f09187d8ce75a
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/pkg-config
+  core/patchelf
+)
+pkg_deps=(
+  core/gcc-libs
+  core/glibc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+
+do_install() {
+  do_default_install
+
+  build_line "Patching ELF binaries:"
+  find "${pkg_prefix}/lib" -type f -executable \
+    -exec sh -c 'file -i "$1" | grep -q "x-sharedlib; charset=binary"' _ {} \; \
+    -print \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(gdalenhance | tail -n 2 | head -1 | awk '{print $2}' | tr -d ',')"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install core/bats --binlink
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install "results/${pkg_artifact}" --binlink --force
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://f94bacdc1f9532190c4cd53d6d9f985ab0332d466ff62374e993f1407a4d75d4 --input-file /src/attributes.yml

Profile: Habitat Core Plan gdal (gdal)
Version: 0.1.0
Target:  docker://f94bacdc1f9532190c4cd53d6d9f985ab0332d466ff62374e993f1407a4d75d4

  ✔  core-plans-gdal-exists: Ensure gdal exists
     ✔  Command: `hab pkg path core/gdal` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/gdal` stdout is expected not to be empty
     ✔  File /hab/pkgs/core/gdal/2.4.0/20200603152237/bin/gdalenhance is expected to exist
  ✔  core-plans-gdal-works: Ensure gdal works as expected
     ✔  Command: `hab pkg path core/gdal` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/gdal` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/gdal/2.4.0/20200603152237 gdalenhance --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/gdal/2.4.0/20200603152237 gdalenhance --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/gdal/2.4.0/20200603152237 gdalenhance --version` stdout is expected to match /GDAL 2.4.0/
     ✔  Command: `DEBUG=true; hab pkg exec core/gdal/2.4.0/20200603152237 gdalenhance --version` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 9 successful, 0 failures, 0 skipped
```